### PR TITLE
Update API to work with latest logbooks server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Jefferson Lab Java Logbook API for programmatic access to the [logbook serve
 ---
 
 ## Install
-This library requires a Java 8+ JVM and standard library at run time. 
+This library requires a Java 11+ JVM and standard library at run time. 
 
 You can obtain the library jar file from the [Maven Central repository](https://repo1.maven.org/maven2/org/jlab/jlog/) directly or from a Maven friendly build tool with the following coordinates (Gradle example shown):
 ```
@@ -48,7 +48,7 @@ The default configuration properties are located in [jlog-default.properties](ht
 In order to interact with the logbook server users must authenticate.  This is done using a [logbook server client certificate](https://logbooks.jlab.org/content/api-authentication), which is assumed to be located in the user's home directory in a file named _.elogcert_.  You can override the location of the certificate with [LogEntry.setClientCertificatePath()](https://jeffersonlab.github.io/jlog/org/jlab/jlog/LogEntry.html#setClientCertificatePath(java.lang.String,boolean)).
 
 ## Build
-This project is built with [Java 17](https://adoptium.net/) (compiled to Java 8 bytecode), and uses the [Gradle 7](https://gradle.org/) build tool to automatically download dependencies and build the project from source:
+This project is built with [Java 17](https://adoptium.net/) (compiled to Java 11 bytecode), and uses the [Gradle 7](https://gradle.org/) build tool to automatically download dependencies and build the project from source:
 
 ```
 git clone https://github.com/JeffersonLab/jlog

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ ext {
 }
 
 tasks.withType(JavaCompile) {
-    options.release = 8
+    options.release = 11
     options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }

--- a/src/integration/java/org/jlab/jlog/CertificateAndServerIntegrationTest.java
+++ b/src/integration/java/org/jlab/jlog/CertificateAndServerIntegrationTest.java
@@ -53,7 +53,7 @@ public class CertificateAndServerIntegrationTest {
 
         Properties config = Library.getConfiguration();
 
-        String logbookHostname = "logbooktest.acc.jlab.org";
+        String logbookHostname = "logbooks9.jlab.org";
 
         config.setProperty("SUBMIT_URL", "https://" + logbookHostname + "/incoming");
         config.setProperty("FETCH_URL", "https://" + logbookHostname + "/entry");

--- a/src/main/java/org/jlab/jlog/LogItem.java
+++ b/src/main/java/org/jlab/jlog/LogItem.java
@@ -886,6 +886,7 @@ abstract class LogItem {
 
             HttpRequest request = HttpRequest.newBuilder()
                             .uri(URI.create(putUrl))
+                            .expectContinue(true)
                             .PUT(HttpRequest.BodyPublishers.ofString(xml))
                             .build();
 

--- a/src/main/java/org/jlab/jlog/LogItem.java
+++ b/src/main/java/org/jlab/jlog/LogItem.java
@@ -6,10 +6,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.net.FileNameMap;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -27,6 +27,7 @@ import java.util.Properties;
 import javax.naming.InvalidNameException;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 import javax.xml.XMLConstants;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -873,15 +874,36 @@ abstract class LogItem {
         boolean ignoreServerCert = "true".equals(props.getProperty("IGNORE_SERVER_CERT_ERRORS"));
 
         try {
+
             String putUrl = buildHttpPutUrl();
-            URL url = new URL(putUrl);
+
+
+            SSLContext sslContext = SecurityUtil.getContext(pemFilePath, !ignoreServerCert);
+
+            HttpClient httpClient = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                            .uri(URI.create(putUrl))
+                            .PUT(HttpRequest.BodyPublishers.ofString(xml))
+                            .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            System.err.println(response.body());
+
+            id = 0;
+            //id = parseServerResponse(response.body());
+
+            /*URL url = new URL(putUrl);
             con = (HttpsURLConnection) url.openConnection();
             con.setSSLSocketFactory(SecurityUtil.getClientCertSocketFactoryPEM(
                     pemFilePath, !ignoreServerCert));
             con.setRequestMethod("PUT");
             con.setDoOutput(true);
-            con.setChunkedStreamingMode(0);
-            con.setRequestProperty("Expect", "100-Continue");
+            //con.setChunkedStreamingMode(0);
+            //con.setRequestProperty("Expect", "100-Continue");
             con.connect();
 
             try (OutputStream out = con.getOutputStream();
@@ -898,7 +920,7 @@ abstract class LogItem {
 
             try (InputStream is = con.getInputStream()) {
                 id = parseServerResponse(is);
-            }
+            }*/
         } catch (MalformedURLException e) {
             throw new LogIOException(
                     "Invalid submission URL: check config file.", e);
@@ -930,6 +952,8 @@ abstract class LogItem {
             throw new LogCertificateException(
                     "Unable to obtain SSL connection due to certificate error.",
                     e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
 
         return id;

--- a/src/main/java/org/jlab/jlog/LogItem.java
+++ b/src/main/java/org/jlab/jlog/LogItem.java
@@ -890,12 +890,9 @@ abstract class LogItem {
                             .PUT(HttpRequest.BodyPublishers.ofString(xml))
                             .build();
 
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
-            System.err.println(response.body());
-
-            id = 0;
-            //id = parseServerResponse(response.body());
+            id = parseServerResponse(response.body());
 
             /*URL url = new URL(putUrl);
             con = (HttpsURLConnection) url.openConnection();


### PR DESCRIPTION
Fixes #3 

Two things are needed to fix this:
- Replace old HttpURLConnection class with java.net.HttpClient
- Force TLSv1.2 (explicitly avoid TLSv1.3)